### PR TITLE
Invalidate cache on all servers

### DIFF
--- a/invalidate-cache.sh
+++ b/invalidate-cache.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
+for i in 1 2; do
+  urls=(
+    "https://p${i}.links.dev/cdn?path=fatih-yavuz/links.dev/main/landing/css/custom.css?refresh=1"
+    "https://p${i}.links.dev/cdn?path=fatih-yavuz/links.dev/main/example-pages.js&refresh=1"
+    "https://p${i}.links.dev/fatih/?refresh-registry=1"
+    "https://p${i}.links.dev/fatih/?refresh=1"
+    "https://p${i}.links.dev/?refresh=1"
+    "https://p${i}.links.dev/cdn?path=fatih-yavuz/links.dev/main/user-page/css/icons.css?reset=1"
+    "https://p${i}.links.dev/cdn?path=fatih-yavuz/links.dev/main/user-page/css/base.css?reset=1"
+    "https://p${i}.links.dev/cdn?path=fatih-yavuz/links.dev/main/user-page/css/reset.css?reset=1"
+  )
 
-urls=(
-  "https://links.dev/cdn?path=fatih-yavuz/links.dev/main/landing/css/custom.css?refresh=1"
-  "https://links.dev/cdn?path=fatih-yavuz/links.dev/main/example-pages.js&refresh=1"
-  "https://links.dev/fatih/?refresh-registry=1"
-  "https://links.dev/fatih/?refresh=1"
-  "https://links.dev/?refresh=1"
-  "https://links.dev/cdn?path=fatih-yavuz/links.dev/main/user-page/css/icons.css?reset=1"
-  "https://links.dev/cdn?path=fatih-yavuz/links.dev/main/user-page/css/base.css?reset=1"
-  "https://links.dev/cdn?path=fatih-yavuz/links.dev/main/user-page/css/reset.css?reset=1"
-)
-
-for url in "${urls[@]}"; do
-  curl -s -w "%{http_code} %{url_effective}\n" "$url" -o /dev/null
+  for url in "${urls[@]}"; do
+    curl -s -w "%{http_code} %{url_effective}\n" "$url" -o /dev/null
+  done
 done


### PR DESCRIPTION
Because we have multiple servers behind the load balancer, the cache invalidation request is being distributed round robin and it causes issues. 

This PR adds invalidation on all servers

Closes #151 